### PR TITLE
changed write test and neighbors

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,12 @@
     "eslint": "^0.22.1"
   },
   "dependencies": {
-    "yargs": "^3.9.0",
-    "underscore": "^1.8.3",
     "arangojs": "^3.8.1",
+    "bluebird": "^2.9.30",
     "mongodb": "^2.0.33",
     "neo4j": "^2.0.0-RC1",
-    "oriento": "^1.1.3"
+    "orientjs": "^2.0.0",
+    "underscore": "^1.8.3",
+    "yargs": "^3.9.0"
   }
 }


### PR DESCRIPTION
Hi, I improved the benchmark for OrientDB with the following changes:

* The OrientDB release tested was 2.0.9, while ArangoDB tested their last alpha. To make the test fair, all of the most recent versions should be tested. We ran the test using the latest OrientDB 2.1-rc4 and the latest version of the OrientJS node.js driver
* The creation of the database wasn’t optimized. We have re-imported the entire database using lightweight edges. To do the same executes this command after creation of a brand new database: “ALTER DATABASE custom useLightweightEdges=true”. We also uploaded the database online at: http://orientdb.com/public-databases/pokec.zip (1.2Gb)
* We fixed the file orientdb/description.js by improving the query and API usage

Please could you re-run the tests and update the results in the article? On my computer OrientDB results ara much better than before. 
Thanks